### PR TITLE
Standardize tags for accounting purposes

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -11,10 +11,9 @@
         disable_rollback: true
         template: "files/cloudformation.json"
         tags:
-          type: "telemetry"
-          application: "spark"
+          Type: "spark"
+          App: "pipeline"
       register: cloudformation
 
     - debug: var=cloudformation
     - command: files/deploy.sh "{{account}}:role/{{cloudformation.stack_outputs.Role}}"
-


### PR DESCRIPTION
`App` and `Type` are the tags we use for accounting. This is just for consistency as there is no recurring cost to CFNs, and it appears lambda functions cannot be tagged.